### PR TITLE
Fix useEffect dependency for order status

### DIFF
--- a/src/components/OrderModal.jsx
+++ b/src/components/OrderModal.jsx
@@ -1,5 +1,5 @@
 import axios from "axios";
-import { use, useEffect, useState } from "react";
+import { useEffect, useState } from "react";
 import { useForm } from "react-hook-form";
 import { useNavigate, useLocation, useOutletContext } from "react-router-dom";
 
@@ -69,7 +69,7 @@ function OrderModal({ mode }) {
     if (order.status !== undefined) {
       setStatus(order.status);
     }
-  }, [status]);
+  }, [order.status]);
 
   return (
     <div


### PR DESCRIPTION
## Summary
- remove unused `use` import
- update effect dependency to track `order.status`

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_687870b6f810832485dc2f7df337bb22